### PR TITLE
Fix: DTS track selection / Added: Batch convert option

### DIFF
--- a/mkvdts2ac3.py
+++ b/mkvdts2ac3.py
@@ -629,8 +629,8 @@ def process(ford):
                 dtstracks[:] = []
                 dtstracks.append(altdtstrackid)
            
-            if not dtstrackid:
-                doprint("  No DTS track found\n", 1)
+            if not dtstracks:
+                doprint("  No DTS tracks found\n", 1)
             elif alreadygotac3 and not args.force:
                 doprint("  Already has AC3 track\n", 1)
             else:


### PR DESCRIPTION
Fixed: The script did convert the last DTS track found and not the first one (as it should and as stipulated in the Readme).
Added: When "force" option is set to true, not just the first one but _all_ available DTS tracks are converted to AC3

Here is a more readable diff with white spaces (intendation) ignored:
https://github.com/dcthomson/mkvdts2ac3.py/pull/10/files?w=1
