### PR TITLE
Respect --new in MP4 mode

### DIFF
--- a/mkvdts2ac3.py
+++ b/mkvdts2ac3.py
@@ -884,7 +884,8 @@ def process(ford):
                             converttitle = "  Converting MKV to MP4 [" + str(jobnum) + "/" + str(totaljobs) + "]..."
                             convertcmd = [ffmpeg, "-i", tempnewmkvfile, "-map", "0", "-vcodec", "copy", "-acodec", "copy", "-c:s", "mov_text", mp4file]
                             runcommand(converttitle, convertcmd)
-                            silentremove(ford)
+                            if not args.new:
+                                silentremove(ford)
                             silentremove(tempnewmkvfile)
                             files.append(fileBaseName + '.mp4')
                         else:


### PR DESCRIPTION
In MP4 mode, the old file was always deleted, even if --new was used. As I read it, --new leaves the original file alongside the new file, so it should be respected even when converting.

This does that - the delete of the original file only happens if args.new is false.
